### PR TITLE
Adding explicit ipykernel install step to RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,6 +22,7 @@ build:
       # VIRTUAL_ENV needs to be set manually for now.
       # See https://github.com/readthedocs/readthedocs.org/pull/11152/
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry run python -m ipykernel install --user --name=vr_python3
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
# Description

This hopefully fixes #399 by adding an explicit `ipykernel install` step to `.readthedocs.yaml` build sequence.

@dalonsoa - this is a bit of an informed guess. I guess we just try it and see what happens, since we can only test by seeing if RTD builds!