### PR TITLE
np.mean error fixed

### DIFF
--- a/virtual_ecosystem/models/hydrology/hydrology_model.py
+++ b/virtual_ecosystem/models/hydrology/hydrology_model.py
@@ -663,7 +663,7 @@ class HydrologyModel(
         # (currently only one value per month, will be average with daily input)
         for var in ["latent_heat_vapourisation", "molar_density_air"]:
             soil_hydrology[var] = DataArray(
-                np.mean(daily_lists[var]),
+                hydro_input[var],
                 dims=self.data["layer_heights"].dims,
                 coords=self.data["layer_heights"].coords,
             )


### PR DESCRIPTION
There was a small error in the hydrology model that caused `ve_run` to throw a warning, this is the fix.


## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
