### PR TITLE
Soil moisture units to mm in data object

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -289,7 +289,7 @@ def dummy_carbon_data(fixture_core_components):
             # At present the soil model only uses the top soil layer, so this is the
             # only one with real test values in
             DataArray(
-                [[0.9304620050, 0.787549327, 0.504263188, 0.302527807]],
+                [[232.61550125, 196.88733175, 126.065797, 75.63195175]],
                 dims=["layers", "cell_id"],
             ),
             DataArray(np.full((1, 4), np.nan), dims=["layers", "cell_id"]),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -708,7 +708,9 @@ def dummy_climate_data(fixture_core_components):
     data["soil_moisture"] = xr.concat(
         [
             DataArray(np.full((13, 3), np.nan), dims=["layers", "cell_id"]),
-            DataArray(np.full((2, 3), 0.20), dims=["layers", "cell_id"]),
+            DataArray(
+                [[5.0, 5.0, 5.0], [500.0, 500.0, 500.0]], dims=["layers", "cell_id"]
+            ),
         ],
         dim="layers",
     )

--- a/tests/models/abiotic/test_energy_balance.py
+++ b/tests/models/abiotic/test_energy_balance.py
@@ -187,19 +187,19 @@ def test_calculate_leaf_and_air_temperature(
     )
 
     exp_air_temp = DataArray(np.full((15, 3), np.nan), dims=["layers", "cell_id"])
-    t_vals = [30.0, 29.99996, 29.99542, 29.50450, 21.425606, 20.09504]
+    t_vals = [30.0, 29.999984, 29.997765, 29.750162, 21.462524, 20.097502]
     exp_air_temp.T[..., [0, 1, 2, 3, 11, 12]] = t_vals
 
     exp_leaf_temp = DataArray(np.full((15, 3), np.nan), dims=["layers", "cell_id"])
-    tl_vals = [30.078712, 29.105456, 27.396327]
+    tl_vals = [30.078712, 29.10546, 27.395564]
     exp_leaf_temp.T[..., [1, 2, 3]] = tl_vals
 
     exp_vp = DataArray(np.full((15, 3), np.nan), dims=["layers", "cell_id"])
-    vp_vals = [0.14, 0.14001, 0.141425, 0.281758, 0.228266, 0.219455]
+    vp_vals = [0.14, 0.14001, 0.141337, 0.275872, 0.134382, 0.111077]
     exp_vp.T[..., [0, 1, 2, 3, 11, 12]] = vp_vals
 
     exp_vpd = DataArray(np.full((15, 3), np.nan), dims=["layers", "cell_id"])
-    vpd_vals = [0.098781, 0.098789, 0.099798, 0.201279, 0.200826, 0.200064]
+    vpd_vals = [0.098781, 0.098788, 0.09973, 0.195867, 0.118112, 0.101256]
     exp_vpd.T[..., [0, 1, 2, 3, 11, 12]] = vpd_vals
 
     exp_gv = DataArray(np.full((15, 3), np.nan), dims=["layers", "cell_id"])
@@ -207,11 +207,11 @@ def test_calculate_leaf_and_air_temperature(
     exp_gv.T[..., [1, 2, 3]] = gv_vals
 
     exp_sens_heat = DataArray(np.full((15, 3), np.nan), dims=["layers", "cell_id"])
-    sens_heat_vals = [0.0, 1.398342, 1.397875, 1.1278, 1.0]
+    sens_heat_vals = [0.0, 1.398342, 1.3979, 1.123268, 1.0]
     exp_sens_heat.T[..., [0, 1, 2, 3, 13]] = sens_heat_vals
 
     exp_latent_heat = DataArray(np.full((15, 3), np.nan), dims=["layers", "cell_id"])
-    lat_heat_vals = [0.0, 8.330052, 8.32997, 8.646973, 1.0]
+    lat_heat_vals = [0.0, 8.330051, 8.329929, 8.651111, 1.0]
     exp_latent_heat.T[..., [0, 1, 2, 3, 13]] = lat_heat_vals
 
     np.testing.assert_allclose(

--- a/tests/models/abiotic/test_energy_balance.py
+++ b/tests/models/abiotic/test_energy_balance.py
@@ -63,8 +63,10 @@ def test_calculate_slope_of_saturated_pressure_curve():
         calculate_slope_of_saturated_pressure_curve,
     )
 
+    const = AbioticConsts()
     result = calculate_slope_of_saturated_pressure_curve(
-        temperature=np.full((4, 3), 20.0)
+        temperature=np.full((4, 3), 20.0),
+        saturated_pressure_slope_parameters=const.saturated_pressure_slope_parameters,
     )
     exp_result = np.full((4, 3), 0.14474)
     np.testing.assert_allclose(result, exp_result, rtol=1e-04, atol=1e-04)

--- a/tests/models/hydrology/test_above_ground.py
+++ b/tests/models/hydrology/test_above_ground.py
@@ -204,7 +204,7 @@ def test_calculate_drainage_map(caplog, grid_type, raises, expected_log_entries)
     log_check(caplog, expected_log_entries)
 
 
-def test_estimate_interception():
+def test_calculate_interception():
     """Test."""
     from virtual_ecosystem.models.hydrology.above_ground import calculate_interception
     from virtual_ecosystem.models.hydrology.constants import HydroConsts

--- a/tests/models/hydrology/test_below_ground.py
+++ b/tests/models/hydrology/test_below_ground.py
@@ -84,7 +84,7 @@ def test_update_soil_moisture():
     np.testing.assert_allclose(result, exp_result, rtol=0.001)
 
 
-def test_convert_soil_moisture_to_water_potential(dummy_climate_data):
+def test_convert_soil_moisture_to_water_potential():
     """Test that function to convert soil moisture to a water potential works."""
     from virtual_ecosystem.models.hydrology.below_ground import (
         convert_soil_moisture_to_water_potential,
@@ -93,9 +93,8 @@ def test_convert_soil_moisture_to_water_potential(dummy_climate_data):
     expected_potentials = np.array(
         [-198467.26813379, -198467.26813379, -198467.26813379]
     )
-    dummy_data = dummy_climate_data
     actual_potentials = convert_soil_moisture_to_water_potential(
-        dummy_data["soil_moisture"].isel(layers=13).to_numpy(),
+        soil_moisture=np.repeat(0.2, 3),
         air_entry_water_potential=HydroConsts.air_entry_water_potential,
         water_retention_curvature=HydroConsts.water_retention_curvature,
         soil_moisture_capacity=HydroConsts.soil_moisture_capacity,

--- a/tests/models/hydrology/test_hydrology_tools.py
+++ b/tests/models/hydrology/test_hydrology_tools.py
@@ -1,0 +1,95 @@
+"""Test module for hydrology.hydrology_model.py."""
+
+import numpy as np
+from xarray import DataArray
+
+
+def test_calculate_layer_thickness():
+    """Test."""
+
+    from virtual_ecosystem.models.hydrology.hydrology_tools import (
+        calculate_layer_thickness,
+    )
+
+    soil_layer_heights = np.array([[-0.5, -0.5, -0.5], [-1.2, -1.2, -1.2]])
+    exp_result = np.array([[500, 500, 500], [700, 700, 700]])
+
+    result = calculate_layer_thickness(soil_layer_heights, 1000)
+
+    np.testing.assert_allclose(result, exp_result)
+
+
+def test_setup_hydrology_input_current_timestep(
+    dummy_climate_data, fixture_core_components
+):
+    """Test that correct values are selected for current time step."""
+
+    from virtual_ecosystem.models.hydrology.hydrology_tools import (
+        setup_hydrology_input_current_timestep,
+    )
+
+    result = setup_hydrology_input_current_timestep(
+        data=dummy_climate_data,
+        time_index=0,
+        days=30,
+        seed=42,
+        layer_roles=fixture_core_components.layer_structure.layer_roles,
+        soil_layer_thickness=np.array([[10, 10, 10], [100, 100, 100]]),
+        soil_moisture_capacity=0.9,
+        soil_moisture_residual=0.1,
+    )
+
+    # Check if all variables were created
+    var_list = [
+        "current_precipitation",
+        "subcanopy_temperature",
+        "subcanopy_humidity",
+        "subcanopy_pressure",
+        "subcanopy_wind_speed",
+        "leaf_area_index_sum"
+        "current_evapotranspiration"
+        "soil_layer_heights"
+        "soil_layer_thickness"
+        "top_soil_moisture_capacity_mm"
+        "top_soil_moisture_residual_mm"
+        "soil_moisture_mm"
+        "previous_accumulated_runoff"
+        "previous_subsurface_flow_accumulated"
+        "groundwater_storage",
+    ]
+
+    variables = [var for var in result if var not in var_list]
+    assert variables
+
+    # check if climate values are selected correctly
+    np.testing.assert_allclose(
+        np.sum(result["current_precipitation"], axis=1),
+        (dummy_climate_data["precipitation"].isel(time_index=0)).to_numpy(),
+    )
+    np.testing.assert_allclose(
+        result["subcanopy_temperature"], dummy_climate_data["air_temperature"][11]
+    )
+    np.testing.assert_allclose(
+        result["subcanopy_humidity"], dummy_climate_data["relative_humidity"][11]
+    )
+    np.testing.assert_allclose(
+        result["subcanopy_pressure"],
+        (dummy_climate_data["atmospheric_pressure_ref"].isel(time_index=0)).to_numpy(),
+    )
+
+
+def test_initialise_soil_moisture_mm(fixture_core_components):
+    """Test soil moisture is initialised correctly."""
+
+    from virtual_ecosystem.models.hydrology.hydrology_tools import (
+        initialise_soil_moisture_mm,
+    )
+
+    result = initialise_soil_moisture_mm(
+        soil_layer_thickness=DataArray([[10, 10, 10, 10], [100, 100, 100, 100]]),
+        layer_structure=fixture_core_components.layer_structure,
+        n_cells=4,
+        initial_soil_moisture=0.5,
+    )
+    exp_result = np.array([[5.0, 5.0, 5.0, 5.0], [50.0, 50.0, 50.0, 50.0]])
+    np.testing.assert_allclose(result[13:15], exp_result)

--- a/tests/models/hydrology/test_hydrology_tools.py
+++ b/tests/models/hydrology/test_hydrology_tools.py
@@ -89,7 +89,7 @@ def test_setup_hydrology_input_current_timestep(
         (dummy_climate_data["atmospheric_pressure_ref"].isel(time_index=0)).to_numpy(),
     )
     np.testing.assert_allclose(
-        result["soil_moisture_true"], DataArray(np.full((2, 3), 50.0))
+        result["soil_moisture_mm"], DataArray(np.full((2, 3), 50.0))
     )
 
 
@@ -106,5 +106,5 @@ def test_initialise_soil_moisture_mm(fixture_core_components):
         n_cells=4,
         initial_soil_moisture=0.5,
     )
-    exp_result = np.array([[5.0, 5.0, 5.0, 5.0], [50.0, 50.0, 50.0, 50.0]])
+    exp_result = DataArray([[5.0, 5.0, 5.0, 5.0], [50.0, 50.0, 50.0, 50.0]])
     np.testing.assert_allclose(result[13:15], exp_result)

--- a/tests/models/soil/test_env_factors.py
+++ b/tests/models/soil/test_env_factors.py
@@ -215,7 +215,6 @@ def test_calculate_clay_impact_on_necromass_decay(dummy_carbon_data):
 
 def test_calculate_leaching_rate(dummy_carbon_data, top_soil_layer_index):
     """Test calculation of solute leaching rates."""
-    from virtual_ecosystem.core.constants import CoreConsts
     from virtual_ecosystem.models.soil.constants import SoilConsts
     from virtual_ecosystem.models.soil.env_factors import calculate_leaching_rate
 
@@ -227,7 +226,6 @@ def test_calculate_leaching_rate(dummy_carbon_data, top_soil_layer_index):
         vertical_flow_rate=vertical_flow_per_day,
         soil_moisture=dummy_carbon_data["soil_moisture"][top_soil_layer_index],
         solubility_coefficient=SoilConsts.solubility_coefficient_lmwc,
-        soil_layer_thickness=CoreConsts.depth_of_active_soil_layer,
     )
 
     assert np.allclose(expected_rate, actual_rate)

--- a/virtual_ecosystem/models/abiotic/constants.py
+++ b/virtual_ecosystem/models/abiotic/constants.py
@@ -248,3 +248,8 @@ class AbioticConsts(ConstantsDataclass):
 
     leaf_emissivity: float = 0.8
     """Leaf emissivity, dimensionless."""
+
+    saturated_pressure_slope_parameters: list[float] = field(
+        default_factory=lambda: [4098.0, 0.6108, 17.27, 237.3]
+    )
+    """List of parameters to calcualte the slope of saturated vapour pressure curve."""

--- a/virtual_ecosystem/models/abiotic/energy_balance.py
+++ b/virtual_ecosystem/models/abiotic/energy_balance.py
@@ -252,22 +252,30 @@ def calculate_longwave_emission(
 
 def calculate_slope_of_saturated_pressure_curve(
     temperature: NDArray[np.float32],
+    saturated_pressure_slope_parameters: list[float],
 ) -> NDArray[np.float32]:
     r"""Calculate slope of the saturated pressure curve.
 
-    TODO move factors to constants, most of them share with simple_abiotic_model
-
     Args:
         temperature: Temperature, [C]
+        saturated_pressure_slope_parameters: List of parameters to calcualte
+            the slope of the saturated vapour pressure curve
 
     Returns:
         Slope of the saturated pressure curve, :math:`\Delta_{v}`
     """
 
     return (
-        4098
-        * (0.6108 * np.exp(17.27 * temperature / (temperature + 237.3)))
-        / (temperature + 237.3) ** 2
+        saturated_pressure_slope_parameters[0]
+        * (
+            saturated_pressure_slope_parameters[1]
+            * np.exp(
+                saturated_pressure_slope_parameters[2]
+                * temperature
+                / (temperature + saturated_pressure_slope_parameters[3])
+            )
+        )
+        / (temperature + saturated_pressure_slope_parameters[3]) ** 2
     )
 
 
@@ -465,7 +473,10 @@ def calculate_leaf_and_air_temperature(
 
     # Factors from vapour pressure linearisation
     delta_v_ref = calculate_slope_of_saturated_pressure_curve(
-        air_temperature_ref.to_numpy()
+        air_temperature_ref.to_numpy(),
+        saturated_pressure_slope_parameters=(
+            abiotic_constants.saturated_pressure_slope_parameters
+        ),
     )
 
     a_E, b_E = vapour_pressure_linearisation(

--- a/virtual_ecosystem/models/abiotic/energy_balance.py
+++ b/virtual_ecosystem/models/abiotic/energy_balance.py
@@ -369,7 +369,8 @@ def calculate_leaf_and_air_temperature(
     * air_temperature_ref: Air temperature at reference height 2m above canopy, [C]
     * vapour_pressure_ref: vapour pressure at reference height 2m above canopy, [kPa]
     * soil_temperature: Soil temperature, [C]
-    * soil_moisture: Relative soil moisture, dimensionless
+    * soil_moisture: Soil moisture, [mm]
+    * layer_heights: Layer heights, [mm]
     * atmospheric_pressure_ref: Atmospheric pressure at reference height, [kPa]
     * air_temperature: Air temperature, [C]
     * canopy_temperature: Leaf temperature, [C]
@@ -402,7 +403,11 @@ def calculate_leaf_and_air_temperature(
 
     # Select variables for current time step and relevant layers
     topsoil_temperature = data["soil_temperature"][topsoil_layer_index]
-    topsoil_moisture = data["soil_moisture"][topsoil_layer_index]
+    topsoil_moisture = (
+        data["soil_moisture"][topsoil_layer_index]
+        / -data["layer_heights"][topsoil_layer_index]
+        / 100
+    )
     air_temperature_ref = data["air_temperature_ref"].isel(time_index=time_index)
     vapour_pressure_ref = data["vapour_pressure_ref"].isel(time_index=time_index)
     atmospheric_pressure_ref = data["atmospheric_pressure_ref"].isel(

--- a/virtual_ecosystem/models/hydrology/above_ground.py
+++ b/virtual_ecosystem/models/hydrology/above_ground.py
@@ -184,8 +184,9 @@ def accumulate_horizontal_flow(
         accumulated (sub-)surface flow, [mm]
     """
 
+    current_flow_true = np.nan_to_num(current_flow, nan=0.0)
     for cell_id, upstream_ids in enumerate(drainage_map.values()):
-        previous_accumulated_flow[cell_id] += np.sum(current_flow[upstream_ids])
+        previous_accumulated_flow[cell_id] += np.sum(current_flow_true[upstream_ids])
 
     if (previous_accumulated_flow < 0.0).any():
         to_raise = ValueError("The accumulated flow should not be negative!")

--- a/virtual_ecosystem/models/hydrology/hydrology_tools.py
+++ b/virtual_ecosystem/models/hydrology/hydrology_tools.py
@@ -1,13 +1,14 @@
-"""Functions to set up hydrology model and select data for each time step."""
+"""Functions to set up hydrology model and select data for current time step."""
 
 # noqa: D205, D415
 
 import numpy as np
 from numpy.typing import NDArray
-from xarray import DataArray
 
+from virtual_ecosystem.core.constants import CoreConsts
 from virtual_ecosystem.core.core_components import LayerStructure
 from virtual_ecosystem.core.data import Data
+from virtual_ecosystem.models.abiotic import abiotic_tools
 from virtual_ecosystem.models.hydrology import above_ground
 
 
@@ -18,11 +19,11 @@ def calculate_layer_thickness(
     """Calculate layer thickness from soil layer depth profile.
 
     Args:
-        soil_layer_heights: soil layer heights, [m]
-        meters_to_mm: meter to millimeter conversion factor
+        soil_layer_heights: Soil layer heights, [m]
+        meters_to_mm: Meter to millimeter conversion factor
 
     Returns:
-        soil layer thickness, mm
+        Soil layer thickness, [mm]
     """
 
     return np.diff(soil_layer_heights, axis=0, prepend=0) * (-meters_to_mm)
@@ -35,24 +36,29 @@ def setup_hydrology_input_current_timestep(
     seed: None | int,
     layer_roles: list[str],
     soil_layer_thickness: NDArray[np.float32],
-    soil_moisture_capacity: float,
-    soil_moisture_residual: float,
+    soil_moisture_capacity: float | NDArray[np.float32],
+    soil_moisture_residual: float | NDArray[np.float32],
+    core_constants: CoreConsts,
+    latent_heat_vap_equ_factors: list[float],
 ) -> dict[str, NDArray[np.float32]]:
-    """Select and pre-process inputs to hydrology.update() for current time step.
+    """Select and pre-process inputs for hydrology.update() for current time step.
 
-    The function resturns a dictionary with the following variables:
+    The function returns a dictionary with the following variables:
 
+    * latent_heat_vapourisation
+    * molar_density_air
     * current_precipitation
     * subcanopy_temperature
     * subcanopy_humidity
     * subcanopy_pressure
+    * subcanopy_wind_speed
     * leaf_area_index_sum
     * current_evapotranspiration
     * soil_layer_heights
     * soil_layer_thickness
     * top_soil_moisture_capacity_mm
     * top_soil_moisture_residual_mm
-    * soil_moisture_mm
+    * soil_moisture_true (no above ground layers)
     * previous_accumulated_runoff
     * previous_subsurface_flow_accumulated
     * groundwater_storage
@@ -60,12 +66,16 @@ def setup_hydrology_input_current_timestep(
     Args:
         data: Data object that contains inputs from the microclimate model, the plant
             model, and the hydrology model that are required for current update
-        time_index: time index
-        days: number of days
-        seed: seed for random rainfall generator
-        layer_roles: list of layer roles
-        soil_moisture_capacity: soil moisture capacity, unitless
-        soil_moisture_residual: soil moisture residual, unitless
+        time_index: Time index of current time step
+        days: Number of days in core time step
+        seed: Seed for random rainfall generator
+        layer_roles: List of layer roles
+        soil_moisture_capacity: Soil moisture capacity, unitless
+        soil_moisture_residual: Soil moisture residual, unitless
+        core_constants: Set of core constants share across all models
+        latent_heat_vap_equ_factors: Factors in calculation of latent heat of
+            vapourisation.
+
 
     Returns:
         dictionary with all variables that are required to run one hydrology update()
@@ -73,21 +83,39 @@ def setup_hydrology_input_current_timestep(
 
     output = {}
 
+    # Calculate latent heat of vapourisation and density of air
+    latent_heat_vapourisation = abiotic_tools.calculate_latent_heat_vapourisation(
+        temperature=data["air_temperature"].to_numpy(),
+        celsius_to_kelvin=core_constants.zero_Celsius,
+        latent_heat_vap_equ_factors=latent_heat_vap_equ_factors,
+    )
+    output["latent_heat_vapourisation"] = latent_heat_vapourisation
+
+    molar_density_air = abiotic_tools.calculate_molar_density_air(
+        temperature=data["air_temperature"].to_numpy(),
+        atmospheric_pressure=data["atmospheric_pressure"].to_numpy(),
+        standard_mole=core_constants.standard_mole,
+        standard_pressure=core_constants.standard_pressure,
+        celsius_to_kelvin=core_constants.zero_Celsius,
+    )
+    output["molar_density_air"] = molar_density_air
+
     # Get atmospheric variables
     output["current_precipitation"] = above_ground.distribute_monthly_rainfall(
         (data["precipitation"].isel(time_index=time_index)).to_numpy(),
         num_days=days,
         seed=seed,
     )
-    output["subcanopy_temperature"] = (
-        data["air_temperature"].isel(layers=layer_roles.index("subcanopy"))
-    ).to_numpy()
-    output["subcanopy_humidity"] = (
-        data["relative_humidity"].isel(layers=layer_roles.index("subcanopy"))
-    ).to_numpy()
-    output["subcanopy_pressure"] = (
-        data["atmospheric_pressure_ref"].isel(time_index=time_index).to_numpy()
-    )
+
+    for out_var, in_var in (
+        ("subcanopy_temperature", "air_temperature"),
+        ("subcanopy_humidity", "relative_humidity"),
+        ("subcanopy_wind_speed", "wind_speed"),
+        ("subcanopy_pressure", "atmospheric_pressure"),
+    ):
+        output[out_var] = (
+            data[in_var].isel(layers=layer_roles.index("subcanopy")).to_numpy()
+        )
 
     # Get inputs from plant model
     output["leaf_area_index_sum"] = data["leaf_area_index"].sum(dim="layers").to_numpy()
@@ -96,21 +124,16 @@ def setup_hydrology_input_current_timestep(
     ).to_numpy()
 
     # Select soil variables
+    # FIXME - there's an implicit axis order built into these calculations (vertical
+    #         profile is axis 0) that needs fixing.
     output["top_soil_moisture_capacity_mm"] = (
         soil_moisture_capacity * soil_layer_thickness[0]
     )
     output["top_soil_moisture_residual_mm"] = (
         soil_moisture_residual * soil_layer_thickness[0]
     )
-    # FIXME - there's an implicit axis order built into these calculations (vertical
-    #         profile is axis 0) that needs fixing.
-
-    # Convert soil moisture (volumetric relative water content) to mm as follows:
-    # water content in mm = relative water content / 100 * depth in mm
-    # Example: for 20% water at 40 cm this would be: 20/100 * 400mm = 80 mm
-    output["soil_moisture_mm"] = (
+    output["soil_moisture_true"] = (  # drop above ground layers
         data["soil_moisture"].isel(layers=data["layer_roles"] == "soil")
-        * soil_layer_thickness
     ).to_numpy()
 
     # Get accumulated runoff/flow and ground water level from previous time step
@@ -126,19 +149,19 @@ def setup_hydrology_input_current_timestep(
 
 
 def initialise_soil_moisture_mm(
-    soil_layer_thickness: DataArray,
+    soil_layer_thickness: NDArray[np.float32],
     layer_structure: LayerStructure,
     n_cells: int,
     initial_soil_moisture: float | NDArray[np.float32],
-) -> DataArray:
+) -> NDArray[np.float32]:
     """Initialise soil moisture in mm.
 
     Args:
-        soil_layer_thickness: soil layer thickness, [mm]
-        layer_structure: layer structure object that contains information about the
+        soil_layer_thickness: Soil layer thickness, [mm]
+        layer_structure: LayerStructure object that contains information about the
             number and identities of vertical layers
         n_cells: Number of grid cells
-        initial_soil_moisture: Initial relavtive soil moisture, dimensionless
+        initial_soil_moisture: Initial relative soil moisture, dimensionless
 
     Returns:
         soil moisture, [mm]
@@ -163,12 +186,7 @@ def initialise_soil_moisture_mm(
     )
 
     # Broadcast 1-dimensional array to grid and assign dimensions and coordinates
-    return DataArray(
-        np.broadcast_to(
-            soil_moisture_values * layer_thickness_array,
-            (n_cells, layer_structure.n_layers),
-        ).T,
-        dims=soil_layer_thickness.dims,
-        coords=soil_layer_thickness.coords,
-        name="soil_moisture",
-    )
+    return np.broadcast_to(
+        soil_moisture_values * layer_thickness_array,
+        (n_cells, layer_structure.n_layers),
+    ).T

--- a/virtual_ecosystem/models/hydrology/hydrology_tools.py
+++ b/virtual_ecosystem/models/hydrology/hydrology_tools.py
@@ -1,0 +1,174 @@
+"""Functions to set up hydrology model and select data for each time step."""
+
+# noqa: D205, D415
+
+import numpy as np
+from numpy.typing import NDArray
+from xarray import DataArray
+
+from virtual_ecosystem.core.core_components import LayerStructure
+from virtual_ecosystem.core.data import Data
+from virtual_ecosystem.models.hydrology import above_ground
+
+
+def calculate_layer_thickness(
+    soil_layer_heights: NDArray[np.float32],
+    meters_to_mm: float,
+) -> NDArray[np.float32]:
+    """Calculate layer thickness from soil layer depth profile.
+
+    Args:
+        soil_layer_heights: soil layer heights, [m]
+        meters_to_mm: meter to millimeter conversion factor
+
+    Returns:
+        soil layer thickness, mm
+    """
+
+    return np.diff(soil_layer_heights, axis=0, prepend=0) * (-meters_to_mm)
+
+
+def setup_hydrology_input_current_timestep(
+    data: Data,
+    time_index: int,
+    days: int,
+    seed: None | int,
+    layer_roles: list[str],
+    soil_layer_thickness: NDArray[np.float32],
+    soil_moisture_capacity: float,
+    soil_moisture_residual: float,
+) -> dict[str, NDArray[np.float32]]:
+    """Select and pre-process inputs to hydrology.update() for current time step.
+
+    The function resturns a dictionary with the following variables:
+
+    * current_precipitation
+    * subcanopy_temperature
+    * subcanopy_humidity
+    * subcanopy_pressure
+    * leaf_area_index_sum
+    * current_evapotranspiration
+    * soil_layer_heights
+    * soil_layer_thickness
+    * top_soil_moisture_capacity_mm
+    * top_soil_moisture_residual_mm
+    * soil_moisture_mm
+    * previous_accumulated_runoff
+    * previous_subsurface_flow_accumulated
+    * groundwater_storage
+
+    Args:
+        data: Data object that contains inputs from the microclimate model, the plant
+            model, and the hydrology model that are required for current update
+        time_index: time index
+        days: number of days
+        seed: seed for random rainfall generator
+        layer_roles: list of layer roles
+        soil_moisture_capacity: soil moisture capacity, unitless
+        soil_moisture_residual: soil moisture residual, unitless
+
+    Returns:
+        dictionary with all variables that are required to run one hydrology update()
+    """
+
+    output = {}
+
+    # Get atmospheric variables
+    output["current_precipitation"] = above_ground.distribute_monthly_rainfall(
+        (data["precipitation"].isel(time_index=time_index)).to_numpy(),
+        num_days=days,
+        seed=seed,
+    )
+    output["subcanopy_temperature"] = (
+        data["air_temperature"].isel(layers=layer_roles.index("subcanopy"))
+    ).to_numpy()
+    output["subcanopy_humidity"] = (
+        data["relative_humidity"].isel(layers=layer_roles.index("subcanopy"))
+    ).to_numpy()
+    output["subcanopy_pressure"] = (
+        data["atmospheric_pressure_ref"].isel(time_index=time_index).to_numpy()
+    )
+
+    # Get inputs from plant model
+    output["leaf_area_index_sum"] = data["leaf_area_index"].sum(dim="layers").to_numpy()
+    output["current_evapotranspiration"] = (
+        data["evapotranspiration"].sum(dim="layers") / days
+    ).to_numpy()
+
+    # Select soil variables
+    output["top_soil_moisture_capacity_mm"] = (
+        soil_moisture_capacity * soil_layer_thickness[0]
+    )
+    output["top_soil_moisture_residual_mm"] = (
+        soil_moisture_residual * soil_layer_thickness[0]
+    )
+    # FIXME - there's an implicit axis order built into these calculations (vertical
+    #         profile is axis 0) that needs fixing.
+
+    # Convert soil moisture (volumetric relative water content) to mm as follows:
+    # water content in mm = relative water content / 100 * depth in mm
+    # Example: for 20% water at 40 cm this would be: 20/100 * 400mm = 80 mm
+    output["soil_moisture_mm"] = (
+        data["soil_moisture"].isel(layers=data["layer_roles"] == "soil")
+        * soil_layer_thickness
+    ).to_numpy()
+
+    # Get accumulated runoff/flow and ground water level from previous time step
+    output["previous_accumulated_runoff"] = data[
+        "surface_runoff_accumulated"
+    ].to_numpy()
+    output["previous_subsurface_flow_accumulated"] = data[
+        "subsurface_flow_accumulated"
+    ].to_numpy()
+    output["groundwater_storage"] = data["groundwater_storage"].to_numpy()
+
+    return output
+
+
+def initialise_soil_moisture_mm(
+    soil_layer_thickness: DataArray,
+    layer_structure: LayerStructure,
+    n_cells: int,
+    initial_soil_moisture: float | NDArray[np.float32],
+) -> DataArray:
+    """Initialise soil moisture in mm.
+
+    Args:
+        soil_layer_thickness: soil layer thickness, [mm]
+        layer_structure: layer structure object that contains information about the
+            number and identities of vertical layers
+        n_cells: Number of grid cells
+        initial_soil_moisture: Initial relavtive soil moisture, dimensionless
+
+    Returns:
+        soil moisture, [mm]
+    """
+
+    # Create 1-dimensional numpy array filled with initial soil moisture values for
+    # all soil layers and np.nan for atmosphere layers
+    soil_moisture_values = np.repeat(
+        a=[np.nan, initial_soil_moisture],
+        repeats=[
+            layer_structure.n_layers - len(layer_structure.soil_layers),
+            len(layer_structure.soil_layers),
+        ],
+    )
+    layer_thickness_array = np.concatenate(
+        [
+            np.repeat(
+                np.nan, layer_structure.n_layers - len(layer_structure.soil_layers)
+            ),
+            soil_layer_thickness[:, 0],
+        ]
+    )
+
+    # Broadcast 1-dimensional array to grid and assign dimensions and coordinates
+    return DataArray(
+        np.broadcast_to(
+            soil_moisture_values * layer_thickness_array,
+            (n_cells, layer_structure.n_layers),
+        ).T,
+        dims=soil_layer_thickness.dims,
+        coords=soil_layer_thickness.coords,
+        name="soil_moisture",
+    )

--- a/virtual_ecosystem/models/soil/carbon.py
+++ b/virtual_ecosystem/models/soil/carbon.py
@@ -73,7 +73,7 @@ def calculate_soil_carbon_updates(
             organic matter [kg C m^-3]
         pH: pH values for each soil grid cell [unitless]
         bulk_density: bulk density values for each soil grid cell [kg m^-3]
-        soil_moisture: relative water content for each soil grid cell [unitless]
+        soil_moisture: amount of water contained by each soil layer [mm]
         soil_water_potential: Soil water potential for each grid cell [kPa]
         soil_temp: soil temperature for each soil grid cell [degrees C]
         clay_fraction: The clay fraction for each soil grid cell [unitless]
@@ -123,7 +123,6 @@ def calculate_soil_carbon_updates(
         vertical_flow_rate=vertical_flow_rate,
         soil_moisture=soil_moisture,
         solubility_coefficient=model_constants.solubility_coefficient_lmwc,
-        soil_layer_thickness=core_constants.depth_of_active_soil_layer,
     )
     pom_decomposition_rate = calculate_enzyme_mediated_decomposition(
         soil_c_pool=soil_c_pool_pom,

--- a/virtual_ecosystem/models/soil/env_factors.py
+++ b/virtual_ecosystem/models/soil/env_factors.py
@@ -273,7 +273,6 @@ def calculate_leaching_rate(
     vertical_flow_rate: NDArray[np.float32],
     soil_moisture: NDArray[np.float32],
     solubility_coefficient: float,
-    soil_layer_thickness: float,
 ) -> NDArray[np.float32]:
     """Calculate leaching rate for a given solute based on flow rate.
 
@@ -281,26 +280,17 @@ def calculate_leaching_rate(
     of solute that is expected to be found in dissolved form is calculated by
     multiplying the solute density by its solubility coefficient. This is then
     multiplied by the frequency with which the water column is completely replaced, i.e.
-    the ratio of vertical flow rate to water column height.
+    the ratio of vertical flow rate to soil moisture in mm.
 
     Args:
         solute_density: The density of the solute in the soil [kg solute m^-3]
         vertical_flow_rate: Rate of flow downwards through the soil [mm day^-1]
-        soil_moisture: Volumetric relative water content of the soil [unitless]
+        soil_moisture: Volume of water contained in topsoil layer [mm]
         solubility_coefficient: The solubility coefficient of the solute in question
             [unitless]
-        soil_layer_thickness: Thickness of the biogeochemically active soil layer [m]
 
     Returns:
         The rate at which the solute in question is leached [kg solute m^-3 day^-1]
     """
 
-    # Vertical flow rate has to be converted into m day^-1
-    vert_flow_meters = vertical_flow_rate / 1e3
-
-    return (
-        solubility_coefficient
-        * solute_density
-        * vert_flow_meters
-        / (soil_moisture * soil_layer_thickness)
-    )
+    return solubility_coefficient * solute_density * vertical_flow_rate / soil_moisture


### PR DESCRIPTION
This PR changes the soil moisture unit to mm in the data object. For some calculations in the hydrology and abiotic model, it is still needed in volumetric moisture content, but I think I reduced the number of conversions.
I also tidied the code based on what we have learned, but there is still a big outstanding issue with accessing indices etc.

@jacobcook1995 could you add the changes needed in the soil model to this branch please?

Fixes #345 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
