### PR TITLE
Initial draft of abiotic model changes for new LayerStructure

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,6 +165,8 @@ def fixture_config():
         reproductive_type = "iteroparous"
         birth_mass = 0.0005
         adult_mass = 0.005
+
+        [hydrology]
         """
 
     return Config(cfg_strings=cfg_string)

--- a/virtual_ecosystem/core/base_model.py
+++ b/virtual_ecosystem/core/base_model.py
@@ -188,8 +188,7 @@ class BaseModel(ABC):
         * ``model_timing``: the
           :class:`~virtual_ecosystem.core.core_components.ModelTiming` instance from
           the ``core_components`` argument.
-        * ``grid``: the
-          :class:`~virtual_ecosystem.core.core_components.Grid` instance from
+        * ``grid``: the :class:`~virtual_ecosystem.core.grid.Grid` instance from
           the ``core_components`` argument.
         * ``layer_structure``: the
           :class:`~virtual_ecosystem.core.core_components.LayerStructure` instance from

--- a/virtual_ecosystem/core/core_components.py
+++ b/virtual_ecosystem/core/core_components.py
@@ -161,12 +161,22 @@ class ModelTiming:
 
 
 class LayerStructure:
-    """Simulation vertical layer structure.
+    """Vertical layer structure of the Virtual Ecosystem.
 
-    This class defines the structure of the vertical dimension of the Virtual Ecosystem
-    from a model configuration. Four values from the ``core.layers`` configuration
-    section are used to define a set of vertical layers and their heights (or relative
-    heights): ``canopy_layers``, ``soil_layers``, ``above_canopy_height_offset`` and
+    This class defines the structure of the vertical dimension of a simulation using the
+    Virtual Ecosystem. The vertical dimension is divided into a series of layers, which
+    perform different roles. Four settings from the ``core.layers`` configuration define
+    these layers, which are arranged from the top to the bottom.
+
+    * ``above_canopy_height_offset``: this defines the height above the canopy top of
+      the first layer role ``above``, which represents the measurement height of
+      reference climate data.
+    * ``canopy_layers``: this defines the fixed number of layers with the ``canopy``
+      role. Not all of these necessarily contain canopy during a simulation as the
+      canopy structure is dynamic
+    * ``surface_layer_heights``: this defines the height above ground level of the
+      ground surface atmospheric layer
+    ``soil_layers``,  and
     ``surface_layer_height``. These values are validated and then assigned to attributes
     of this class. The ``n_layers`` and ``layer_roles`` attributes report the total
     number of layers in the vertical dimension and an array giving the vertical sequence


### PR DESCRIPTION
# Description

This PR implements the updates to the `LayerStructure` object described in #451 and a few more things.

* The class is refactored from a dataclass to a standard class. As more methods were added, it got easier to define attributes within `__init__`.
* The `set_filled_canopy` method now takes an array of canopy heights and updates the `filled_canopy` role indexing and the `lowest_canopy_filled` attribute.
* The use of the `role_indices` attribute has switched over to using the  new`get_indices` method. This allows users to request aggregate indices (`['above', 'filled_canopy', 'surface']`) and get a single array of integer or boolean layer indices. Aggregate indices are cached on request and updated by `set_filled_canopy` so they don't get outdated.

  This will break the current use of `layer_structure.role_indices` in #421 but that should be a fairly straight swap and results in a much clearer interface: the code explicitly states what roles are needed.

Fixes #451

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
