### PR TITLE
np.abs wind speed at reference height

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -841,7 +841,7 @@ def dummy_climate_data(fixture_core_components):
     # ------------------------------------------------------------------
     reference_fields = {
         "air_temperature_ref": [23.0, 24.0, 25.0, 26.0],
-        "wind_speed_ref": [0.5, 0.8, 1.2, 1.8],
+        "wind_speed_ref": [-0.5, 0.8, 1.2, 1.8],
         "relative_humidity_ref": [90.0, 82.0, 72.0, 60.0],
         "vapour_pressure_deficit_ref": [0.14, 0.30, 0.65, 1.10],
         "vapour_pressure_ref": [2.2, 2.1, 1.9, 1.6],

--- a/tests/models/abiotic/test_wind.py
+++ b/tests/models/abiotic/test_wind.py
@@ -61,8 +61,8 @@ def test_calculate_wind_profile(dummy_climate_data, fixture_core_components):
 
     result = calculate_wind_profile(
         reference_wind_speed=np.abs(
-            data["wind_speed_ref"].isel(time_index=0)
-        ).to_numpy(),
+            data["wind_speed_ref"].isel(time_index=0).to_numpy()
+        ),
         reference_height=data["layer_heights"][0].to_numpy() + 10.0,
         wind_heights=data["layer_heights"][lyr_str.index_filled_atmosphere].to_numpy(),
         roughness_length=data["roughness_length_momentum"].to_numpy(),
@@ -95,8 +95,8 @@ def test_calculate_friction_velocity(dummy_climate_data):
 
     result = calculate_friction_velocity(
         reference_wind_speed=np.abs(
-            data["wind_speed_ref"].isel(time_index=0)
-        ).to_numpy(),
+            data["wind_speed_ref"].isel(time_index=0).to_numpy()
+        ),
         reference_height=data["layer_heights"][0].to_numpy() + 10.0,
         roughness_length=data["roughness_length_momentum"].to_numpy(),
         zero_plane_displacement=data["zero_plane_displacement"].to_numpy(),

--- a/tests/models/abiotic/test_wind.py
+++ b/tests/models/abiotic/test_wind.py
@@ -60,7 +60,9 @@ def test_calculate_wind_profile(dummy_climate_data, fixture_core_components):
     data = dummy_climate_data
 
     result = calculate_wind_profile(
-        reference_wind_speed=data["wind_speed_ref"].isel(time_index=0).to_numpy(),
+        reference_wind_speed=np.abs(
+            data["wind_speed_ref"].isel(time_index=0)
+        ).to_numpy(),
         reference_height=data["layer_heights"][0].to_numpy() + 10.0,
         wind_heights=data["layer_heights"][lyr_str.index_filled_atmosphere].to_numpy(),
         roughness_length=data["roughness_length_momentum"].to_numpy(),
@@ -92,7 +94,9 @@ def test_calculate_friction_velocity(dummy_climate_data):
     data = dummy_climate_data
 
     result = calculate_friction_velocity(
-        reference_wind_speed=data["wind_speed_ref"].isel(time_index=0).to_numpy(),
+        reference_wind_speed=np.abs(
+            data["wind_speed_ref"].isel(time_index=0)
+        ).to_numpy(),
         reference_height=data["layer_heights"][0].to_numpy() + 10.0,
         roughness_length=data["roughness_length_momentum"].to_numpy(),
         zero_plane_displacement=data["zero_plane_displacement"].to_numpy(),

--- a/tests/models/abiotic_simple/test_microclimate_simple.py
+++ b/tests/models/abiotic_simple/test_microclimate_simple.py
@@ -26,7 +26,7 @@ def test_varying_canopy_log_interpolation(
     layer_structure = fixture_core_components.layer_structure
     data = dummy_climate_data
 
-    reference_data = data["wind_speed_ref"].isel(time_index=0).to_numpy()
+    reference_data = np.abs(data["wind_speed_ref"].isel(time_index=0)).to_numpy()
     layer_heights = data["layer_heights"].to_numpy()
     leaf_area_index_sum = np.nansum(data["leaf_area_index"], axis=0)
 

--- a/tests/models/abiotic_simple/test_microclimate_simple.py
+++ b/tests/models/abiotic_simple/test_microclimate_simple.py
@@ -26,7 +26,7 @@ def test_varying_canopy_log_interpolation(
     layer_structure = fixture_core_components.layer_structure
     data = dummy_climate_data
 
-    reference_data = np.abs(data["wind_speed_ref"].isel(time_index=0)).to_numpy()
+    reference_data = np.abs(data["wind_speed_ref"].isel(time_index=0).to_numpy())
     layer_heights = data["layer_heights"].to_numpy()
     leaf_area_index_sum = np.nansum(data["leaf_area_index"], axis=0)
 

--- a/virtual_ecosystem/models/abiotic/microclimate.py
+++ b/virtual_ecosystem/models/abiotic/microclimate.py
@@ -188,6 +188,9 @@ def calculate_wind_profiles(
     )
 
     #   Wind speed, [m s-1]
+    # The reference wind speed is positive or negative depending on the wind direction.
+    # Since we do not take direction into account, and to ensure correct computation of
+    # wind profiles, the wind speed should be always positive going into the equations.
     wind_reference_height = (
         static["canopy_height"] + abiotic_constants.wind_reference_height
     )

--- a/virtual_ecosystem/models/abiotic/microclimate.py
+++ b/virtual_ecosystem/models/abiotic/microclimate.py
@@ -191,7 +191,9 @@ def calculate_wind_profiles(
     wind_reference_height = (
         static["canopy_height"] + abiotic_constants.wind_reference_height
     )
-    reference_wind_speed = data["wind_speed_ref"].isel(time_index=time_index).to_numpy()
+    reference_wind_speed = np.abs(
+        data["wind_speed_ref"].isel(time_index=time_index).to_numpy()
+    )
 
     wind_speed = layer_structure.from_template()
     wind_speed[layer_structure.index_filled_atmosphere] = wind.calculate_wind_profile(

--- a/virtual_ecosystem/models/abiotic_simple/microclimate_simple.py
+++ b/virtual_ecosystem/models/abiotic_simple/microclimate_simple.py
@@ -137,6 +137,9 @@ def run_simple_microclimate(
         ).rename(var)
 
     # Interpolate wind profiles
+    # The reference wind speed is positive or negative depending on the wind direction.
+    # Since we do not take direction into account, and to ensure correct computation of
+    # wind profiles, the wind speed should be always positive going into the equations.
     lower_wind, upper_wind, gradient_wind = getattr(bounds, "wind_speed")
     reference_wind_speed = np.abs(
         data["wind_speed_ref"].isel(time_index=time_index).to_numpy()

--- a/virtual_ecosystem/models/abiotic_simple/microclimate_simple.py
+++ b/virtual_ecosystem/models/abiotic_simple/microclimate_simple.py
@@ -138,8 +138,12 @@ def run_simple_microclimate(
 
     # Interpolate wind profiles
     lower_wind, upper_wind, gradient_wind = getattr(bounds, "wind_speed")
+    reference_wind_speed = np.abs(
+        data["wind_speed_ref"].isel(time_index=time_index).to_numpy()
+    )
+
     output["wind_speed"] = log_interpolation(
-        reference_data=data["wind_speed_ref"].isel(time_index=time_index).to_numpy(),
+        reference_data=reference_wind_speed,
         leaf_area_index_sum=leaf_area_index_sum,
         layer_structure=layer_structure,
         layer_heights=data["layer_heights"].to_numpy(),


### PR DESCRIPTION
The reference wind speed is positive or negative depending on the wind direction. Since we do not take direction into account, and to ensure correct computation of wind profiles, the wind speed should be always positive going into the equations.

Fixes #1795 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Relevant documentation reviewed and updated
