### PR TITLE
added coordinates to groundwater storage

### DIFF
--- a/tests/models/hydrology/test_hydrology_model.py
+++ b/tests/models/hydrology/test_hydrology_model.py
@@ -226,6 +226,7 @@ def test_setup_and_update_hydrology_model_ranges(
     exp_groundwater = DataArray(
         np.full((2, fixture_core_components.grid.n_cells), 450.0),
         dims=("groundwater_layers", "cell_id"),
+        coords={"groundwater_layers": [14, 15], "cell_id": [0, 1, 2, 3]},
     )
     np.testing.assert_allclose(
         model.data["groundwater_storage"],

--- a/virtual_ecosystem/models/hydrology/hydrology_model.py
+++ b/virtual_ecosystem/models/hydrology/hydrology_model.py
@@ -303,9 +303,17 @@ class HydrologyModel(
             self.initial_groundwater_saturation
             * self.model_constants.groundwater_capacity
         )
+        groundwater_layer_indices = [
+            int(self.layer_structure.n_layers),
+            int(self.layer_structure.n_layers) + 1,
+        ]
         self.data["groundwater_storage"] = DataArray(
             np.full((2, self.grid.n_cells), initial_groundwater_storage),
             dims=("groundwater_layers", "cell_id"),
+            coords={
+                "groundwater_layers": groundwater_layer_indices,
+                "cell_id": self.grid.cell_id,
+            },
             name="groundwater_storage",
         )
 
@@ -866,6 +874,7 @@ class HydrologyModel(
         soil_hydrology["groundwater_storage"] = DataArray(
             daily_lists["groundwater_storage"][day],
             dims=self.data["groundwater_storage"].dims,
+            coords=self.data["groundwater_storage"].coords,
         )
 
         # Update data object


### PR DESCRIPTION
This PR adds coordinates to `groundwater_layers` so they can be accessed the same way as the other layers in the output. I gave them indices following the main layers, so [14,15] following [0,...13].
<img width="810" height="442" alt="image" src="https://github.com/user-attachments/assets/548af5f8-ddea-464b-8512-c53ab4730707" />


Fixes #1760 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Relevant documentation reviewed and updated
