### PR TITLE
Deleted repeated function for soil moisture response

### DIFF
--- a/tests/models/litter/test_env_factors.py
+++ b/tests/models/litter/test_env_factors.py
@@ -26,28 +26,6 @@ def test_calculate_temperature_effect_on_litter_decomp(
     assert np.allclose(actual_factor, expected_factor)
 
 
-def test_calculate_soil_water_effect_on_litter_decomp(
-    dummy_litter_data, fixture_core_components, fixture_litter_constants
-):
-    """Test that soil moisture effects on decomposition are calculated correctly."""
-    from virtual_ecosystem.models.litter.env_factors import (
-        calculate_soil_water_effect_on_litter_decomp,
-    )
-
-    expected_factor = [1.0, 0.88496823, 0.71093190, 0.71093190]
-
-    actual_factor = calculate_soil_water_effect_on_litter_decomp(
-        water_potential=dummy_litter_data["matric_potential"][
-            fixture_core_components.layer_structure.index_topsoil_scalar
-        ],
-        water_potential_halt=fixture_litter_constants.litter_decay_water_potential_halt,
-        water_potential_opt=fixture_litter_constants.litter_decay_water_potential_optimum,
-        moisture_response_curvature=fixture_litter_constants.moisture_response_curvature,
-    )
-
-    assert np.allclose(actual_factor, expected_factor)
-
-
 @pytest.mark.parametrize(
     "increased_depth,expected_av_temps",
     [

--- a/virtual_ecosystem/models/litter/env_factors.py
+++ b/virtual_ecosystem/models/litter/env_factors.py
@@ -9,6 +9,9 @@ from xarray import DataArray
 
 from virtual_ecosystem.core.core_components import LayerStructure
 from virtual_ecosystem.models.litter.model_config import LitterConstants
+from virtual_ecosystem.models.soil.env_factors import (
+    calculate_water_potential_impact_on_microbes,
+)
 
 
 def calculate_environmental_factors(
@@ -78,11 +81,11 @@ def calculate_environmental_factors(
     }
 
     # Calculate the water factor (relevant for below ground layers)
-    water_factor = calculate_soil_water_effect_on_litter_decomp(
+    water_factor = calculate_water_potential_impact_on_microbes(
         water_potential=water_potential,
         water_potential_halt=constants.litter_decay_water_potential_halt,
         water_potential_opt=constants.litter_decay_water_potential_optimum,
-        moisture_response_curvature=constants.moisture_response_curvature,
+        response_curvature=constants.moisture_response_curvature,
     )
 
     return {
@@ -118,42 +121,6 @@ def calculate_temperature_effect_on_litter_decomp(
     return np.exp(
         temp_response * (temperature - reference_temp) / (temperature + offset_temp)
     )
-
-
-def calculate_soil_water_effect_on_litter_decomp(
-    water_potential: NDArray[np.floating],
-    water_potential_halt: float,
-    water_potential_opt: float,
-    moisture_response_curvature: float,
-) -> NDArray[np.floating]:
-    """Calculate the effect that soil water potential has on litter decomposition rates.
-
-    This function is only relevant for the below ground litter pools. Its functional
-    form is taken from :cite:t:`moyano_responses_2013`.
-
-    Args:
-        water_potential: Soil water potential [kPa]
-        water_potential_halt: Water potential at which all microbial activity stops
-            [kPa]
-        water_potential_opt: Optimal water potential for microbial activity [kPa]
-        moisture_response_curvature: Parameter controlling the curvature of the moisture
-            response function [unitless]
-
-    Returns:
-        A multiplicative factor capturing the impact of moisture on below ground litter
-        decomposition [unitless]
-    """
-
-    # TODO - Need to make sure that this function is properly defined for a plausible
-    # range of matric potentials.
-
-    # Calculate how much moisture suppresses microbial activity
-    suppression = (
-        (np.log10(-water_potential) - np.log10(-water_potential_opt))
-        / (np.log10(-water_potential_halt) - np.log10(-water_potential_opt))
-    ) ** moisture_response_curvature
-
-    return 1 - suppression
 
 
 def average_temperature_over_microbially_active_layers(

--- a/virtual_ecosystem/models/soil/env_factors.py
+++ b/virtual_ecosystem/models/soil/env_factors.py
@@ -131,6 +131,11 @@ def calculate_water_potential_impact_on_microbes(
     water potential at which microbial activity ceases suppression is (by definition)
     total, so values of zero are produced.
 
+    The microbial rates effected by the function can be explicit rates (used in the soil
+    model), or implicit rates (i.e. the decay rates of below ground litter pools). In
+    both cases the same functional response is used (which is taken from
+    :cite:t:`moyano_responses_2013`).
+
     Args:
         water_potential: Soil water potential [kPa]
         water_potential_halt: Water potential at which all microbial activity stops


### PR DESCRIPTION
# Description

This is a small PR to delete a function that is repeated between the soil and litter models. It makes it easier to maintain if only a single copy is kept. The motivation for doing this is that I (slightly) improved the soil model version and forgot to also update the litter model version, something that switching to only defining a single function should prevent this from happening in future.

I'm  tagging the whole code development team as reviewers as this basically just needs a "this isn't a terrible idea" thumbs up rather than any specific and/or detailed feedback

Fixes #1803

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
