### PR TITLE
Removed deprecated threshold check in calculate_pH_suitability

### DIFF
--- a/tests/models/soil/test_env_factors.py
+++ b/tests/models/soil/test_env_factors.py
@@ -145,48 +145,6 @@ def test_calculate_pH_suitability(fixture_soil_constants):
     assert np.allclose(expected_inhib, actual_inhib)
 
 
-@pytest.mark.parametrize(
-    argnames=["params"],
-    argvalues=[
-        pytest.param(
-            {
-                "maximum_pH": 7.0,
-                "minimum_pH": 2.5,
-                "lower_optimum_pH": 4.5,
-                "upper_optimum_pH": 7.5,
-            },
-            id="maximum_pH too low",
-        ),
-        pytest.param(
-            {
-                "maximum_pH": 11.0,
-                "minimum_pH": 2.5,
-                "lower_optimum_pH": 1.5,
-                "upper_optimum_pH": 7.5,
-            },
-            id="lower_optimum_pH too low",
-        ),
-        pytest.param(
-            {
-                "maximum_pH": 11.0,
-                "minimum_pH": 2.5,
-                "lower_optimum_pH": 4.5,
-                "upper_optimum_pH": 3.5,
-            },
-            id="upper_optimum_pH too low",
-        ),
-    ],
-)
-def test_calculate_pH_suitability_errors(params):
-    """Test that calculation of pH suitability generates errors if constants are bad."""
-    from virtual_ecosystem.models.soil.env_factors import calculate_pH_suitability
-
-    pH_values = np.array([3.0, 7.5, 9.0, 5.7, 2.0, 11.5])
-
-    with pytest.raises(ValueError):
-        calculate_pH_suitability(soil_pH=pH_values, **params)
-
-
 def test_calculate_clay_impact_on_enzyme_saturation(
     dummy_carbon_data, fixture_soil_constants
 ):

--- a/virtual_ecosystem/models/soil/env_factors.py
+++ b/virtual_ecosystem/models/soil/env_factors.py
@@ -12,7 +12,6 @@ from scipy.special import expit
 from xarray import DataArray
 
 from virtual_ecosystem.core.core_components import LayerStructure
-from virtual_ecosystem.core.logger import LOGGER
 from virtual_ecosystem.models.soil.model_config import SoilConstants
 
 
@@ -183,18 +182,6 @@ def calculate_pH_suitability(
     Returns:
         A multiplicative factor capturing the effect of pH on microbial rates
     """
-
-    # TODO - This check is necessary to prevent nonsensical output being generated,
-    # however it could be done when constants are loaded, rather than for every function
-    # call
-    if (
-        maximum_pH <= upper_optimum_pH
-        or upper_optimum_pH <= lower_optimum_pH
-        or lower_optimum_pH <= minimum_pH
-    ):
-        to_raise = ValueError("At least one pH threshold has an invalid value!")
-        LOGGER.error(to_raise)
-        raise to_raise
 
     pH_factors = np.full(len(soil_pH), np.nan)
 


### PR DESCRIPTION
# Description

Title. I realised that the check for consistent pH thresholds was already done at model configuration, so it was literally just a case of deleted the (totally unnecessary) check within the function

Fixes #1804

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Relevant documentation reviewed and updated
