### PR TITLE
1782 fix high subcanopy evaporation

### DIFF
--- a/tests/models/plants/conftest.py
+++ b/tests/models/plants/conftest.py
@@ -324,6 +324,7 @@ def fixture_canopy_layer_data(
     subcanopy_vegetation_lai = (
         plants_data["subcanopy_vegetation_biomass"]
         * fixture_plants_constants.subcanopy_specific_leaf_area
+        * fixture_plants_constants.subcanopy_leaf_fraction
     )
     subcanopy_transmission = np.exp(
         -fixture_plants_constants.subcanopy_extinction_coef * subcanopy_vegetation_lai

--- a/virtual_ecosystem/models/abiotic/microclimate.py
+++ b/virtual_ecosystem/models/abiotic/microclimate.py
@@ -60,12 +60,7 @@ def prepare_static_inputs(
     leaf_area_index = data["leaf_area_index"].copy().to_numpy()
 
     # Evapotranspiration from plant and hydrology model, [mm per time interval]
-    # TODO #1782 LAI and thus canopy evaporation in surface layer is exploding
-    # As an intermediate fix, set canopy evaporation to average value when LAI >5m m-1
     evapotranspiration = (data["canopy_evaporation"] + data["transpiration"]).to_numpy()
-    evapotranspiration[idx.surface] = np.where(
-        leaf_area_index[idx.surface] > 5.0, 1.0, evapotranspiration[idx.surface]
-    )
 
     # Atmospheric pressure profile set to reference value, [kPa]
     atmospheric_pressure = abiotic_tools.update_profile_from_reference(

--- a/virtual_ecosystem/models/plants/model_config.py
+++ b/virtual_ecosystem/models/plants/model_config.py
@@ -56,9 +56,9 @@ class PlantsConstants(Configuration):
     """The specific leaf area of subcanopy vegetation (m2 kg-1)."""
 
     subcanopy_maximum_leaf_area_index: float = 5
-    """A cap on the maximum leaf area index from the subcanopy. This is an temporary
+    """A cap on the maximum leaf area index from the subcanopy. This is a temporary
     safeguard to prevent subcanopy dynamics from driving unrealistic abiotic conditions
-    and should be replaced by biological limitations on subcanopy growth. (m2 m)"""
+    and should be replaced by biological limitations on subcanopy growth (m2 m-2)."""
 
     subcanopy_respiration_fraction: float = 0.1
     """The fraction of gross primary productivity used in respiration (unitless)."""

--- a/virtual_ecosystem/models/plants/model_config.py
+++ b/virtual_ecosystem/models/plants/model_config.py
@@ -48,8 +48,17 @@ class PlantsConstants(Configuration):
     subcanopy_extinction_coef: float = 0.5
     """The extinction coefficient of subcanopy vegetation (unitless)."""
 
+    subcanopy_leaf_fraction: float = 0.5
+    """The fraction of subcanopy vegetation biomass allocated to leaf tissue rather than
+    to stems and other structural tissue (unitless)."""
+
     subcanopy_specific_leaf_area: float = 14
     """The specific leaf area of subcanopy vegetation (m2 kg-1)."""
+
+    subcanopy_maximum_leaf_area_index: float = 5
+    """A cap on the maximum leaf area index from the subcanopy. This is an temporary
+    safeguard to prevent subcanopy dynamics from driving unrealistic abiotic conditions
+    and should be replaced by biological limitations on subcanopy growth. (m2 m)"""
 
     subcanopy_respiration_fraction: float = 0.1
     """The fraction of gross primary productivity used in respiration (unitless)."""

--- a/virtual_ecosystem/models/plants/subcanopy.py
+++ b/virtual_ecosystem/models/plants/subcanopy.py
@@ -543,11 +543,15 @@ class Subcanopy:
     def set_light_capture(self, below_canopy_light_fraction: NDArray) -> None:
         r"""Calculate the leaf area index and absorption of subcanopy vegetation.
 
-        The subcanopy vegetation is represented as pure leaf biomass (:math:`M_{SC}`, kg
-        m-2), with an associated extinction coefficient (:math:`k`) and specific leaf
-        area (:math:`\sigma`, kg m-2) set in the model constants. These can be used to
-        calculate the leaf area index (:math:`L`) and hence the absorption fraction
-        (:math:`f_{a}`) of  the subcanopy vegetation layer via the Beer-Lambert law: 
+        The subcanopy vegetation is represented as a mixture of structural and leaf
+        biomass, where the
+        :attr:`virtual_ecosystem.models.plants.model_config.PlantConstants.subcanopy_leaf_fraction`
+        defines the fraction associated with subcanopy structural tissue. The remaining
+        leaf biomass (:math:`M_{SC}`, kg m-2) has an associated extinction coefficient
+        (:math:`k`) and specific leaf area (:math:`\sigma`, kg m-2) set in the model
+        constants. These can be used to calculate the leaf area index (:math:`L`) and
+        hence the absorption fraction (:math:`f_{a}`) of  the subcanopy vegetation layer
+        via the Beer-Lambert law: 
 
         .. math ::
             :nowrap:
@@ -558,13 +562,27 @@ class Subcanopy:
                     f_a = e^{-kL}
                 \end{align*}
             \]
+
+        .. WARNING::
+
+            The subcanopy growth dynamics can lead to very high leaf area index in the
+            subcanopy, which crash the calculation of abiotic balances in the
+            model. Currently the subcanopy LAI is explicitly capped, using the setting
+            :attr:`virtual_ecosystem.models.plants.model_config.PlantConstants.subcanopy_maximum_leaf_area_index`
+            to artificially prevent model crashes. This is a temporary feature and
+            should be replaced by better biological and environmental control of
+            subcanopy growth.
         """
 
         # Calculate the leaf area index - values are already in kg m-2 so no need to
-        # account for the area occupied by the biomass - and set the leaf area
-        self.lai = (
+        # account for the area occupied by the biomass. This code accounts for the
+        # structural fraction of the subcanopy and caps the resulting LAI.
+        self.lai = np.clip(
             self.data["subcanopy_vegetation_biomass"].to_numpy()
             * self.model_constants.subcanopy_specific_leaf_area
+            * self.model_constants.subcanopy_leaf_fraction,
+            a_min=0,
+            a_max=self.model_constants.subcanopy_maximum_leaf_area_index,
         )
 
         # Beer-Lambert transmission - note that this is 1 when there is no biomass and

--- a/virtual_ecosystem/models/plants/subcanopy.py
+++ b/virtual_ecosystem/models/plants/subcanopy.py
@@ -545,7 +545,7 @@ class Subcanopy:
 
         The subcanopy vegetation is represented as a mixture of structural and leaf
         biomass, where the
-        :attr:`virtual_ecosystem.models.plants.model_config.PlantConstants.subcanopy_leaf_fraction`
+        :attr:`virtual_ecosystem.models.plants.model_config.PlantsConstants.subcanopy_leaf_fraction`
         defines the fraction associated with subcanopy structural tissue. The remaining
         leaf biomass (:math:`M_{SC}`, kg m-2) has an associated extinction coefficient
         (:math:`k`) and specific leaf area (:math:`\sigma`, kg m-2) set in the model
@@ -568,7 +568,7 @@ class Subcanopy:
             The subcanopy growth dynamics can lead to very high leaf area index in the
             subcanopy, which crash the calculation of abiotic balances in the
             model. Currently the subcanopy LAI is explicitly capped, using the setting
-            :attr:`virtual_ecosystem.models.plants.model_config.PlantConstants.subcanopy_maximum_leaf_area_index`
+            :attr:`virtual_ecosystem.models.plants.model_config.PlantsConstants.subcanopy_maximum_leaf_area_index`
             to artificially prevent model crashes. This is a temporary feature and
             should be replaced by better biological and environmental control of
             subcanopy growth.

--- a/virtual_ecosystem/models/plants/subcanopy.py
+++ b/virtual_ecosystem/models/plants/subcanopy.py
@@ -543,15 +543,18 @@ class Subcanopy:
     def set_light_capture(self, below_canopy_light_fraction: NDArray) -> None:
         r"""Calculate the leaf area index and absorption of subcanopy vegetation.
 
-        The subcanopy vegetation is represented as a mixture of structural and leaf
-        biomass, where the
+        The subcanopy vegetation is represented as a single pool of biomass with
+        associated stoichiometric values but, when calculating light capture, the pool
+        is divided into structural and leaf biomass components. The
         :attr:`virtual_ecosystem.models.plants.model_config.PlantsConstants.subcanopy_leaf_fraction`
-        defines the fraction associated with subcanopy structural tissue. The remaining
-        leaf biomass (:math:`M_{SC}`, kg m-2) has an associated extinction coefficient
-        (:math:`k`) and specific leaf area (:math:`\sigma`, kg m-2) set in the model
-        constants. These can be used to calculate the leaf area index (:math:`L`) and
-        hence the absorption fraction (:math:`f_{a}`) of  the subcanopy vegetation layer
-        via the Beer-Lambert law: 
+        configuration setting defines the subcanopy leaf biomass (:math:`M_{SC}`, kg C
+        m-2) as a fraction of the total subcanopy biomass pool.
+        
+        The model consstants also define subcanopy values for the light extinction
+        coefficient (:math:`k`) and specific leaf area (:math:`\sigma`, m2 kg-1 C).
+        These can be used to calculate the leaf area index (:math:`L`) and hence the
+        absorption fraction (:math:`f_{a}`) of  the subcanopy leaf biomass via the
+        Beer-Lambert law: 
 
         .. math ::
             :nowrap:


### PR DESCRIPTION
# Description

This PR makes some simple changes to control subcanopy LAI:

* It adds a subcanopy leaf fraction config setting (default of 0.5) that removes a fraction of sub canopy vegetation biomass representing stems and structural material before calculating LAI.
* Adds a more hacky cap on maximum subcanopy LAI to avoid abiotic model blowups, controlled by a new config setting. We expect to replace this with more biological models of LAI limitation, but this is a sensible safeguard for now to stop a known issue.
* It removes the existing cap on this that is only implemented in abiotic and makes the cap a general model feature. 

Of note - the example data makes this problem very acute by overestimating the SWD by about an order of magnitude and having essentially open grassland as the scenario.

Fixes #1782 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Relevant documentation reviewed and updated
