### PR TITLE
Improve biomasses exportability

### DIFF
--- a/tests/models/plants/test_biomasses.py
+++ b/tests/models/plants/test_biomasses.py
@@ -301,6 +301,24 @@ def test_Biomasses_from_cohorts(fixture_biomass_components, fixture_biomasses):
         )
 
 
+def test_Biomasses_to_dataframe(fixture_biomass_components):
+    """Test the biomass to_dataframe method works."""
+    from virtual_ecosystem.models.plants.biomasses import Biomasses
+
+    cohorts, allometry, _, _ = fixture_biomass_components
+
+    biomasses = Biomasses.from_cohorts(
+        cohorts=cohorts,
+        allometry=allometry,
+    )
+
+    df = biomasses.to_dataframe()
+
+    # Just check it runs and has the right shape - 2 rows for cohorts and then
+    # 19 columns: cohort id + 3 elements for each of 5 tissues and surplus pools
+    assert df.shape == (2, 19)
+
+
 def test_total_element_mass_and_deficit(fixture_biomasses):
     """Test the total element mass and deficit calculations in StemStoichiometry."""
 

--- a/tests/models/plants/test_biomasses.py
+++ b/tests/models/plants/test_biomasses.py
@@ -12,10 +12,15 @@ ELEMENTS = ((1, "n"), (2, "p"))
 
 @pytest.fixture
 def fixture_biomass_components():
-    """Provides a tuple of biomass components."""
+    """Data for generating biomass instances.
+
+    Provides a tuple of biomass components containing the minimal required data for
+    creating Biomass tissues.
+    """
 
     cohorts = pd.DataFrame(
         dict(
+            cohort_id=["C1", "C2"],
             zeta=[0.1, 0.1],
             sla=[2.0, 2.0],
             fruit_seed_foliage_mass_fraction=[0.5, 0.5],
@@ -223,7 +228,7 @@ def test_BiomassTissue_append(fixture_biomass_components, tissue_class):
     biomasses_2 = BiomassTissueClass(cohorts=cohorts, allometry=allometry)
     biomasses_2.elemental_masses *= 2
 
-    # Append
+    # Test Append
     biomasses_1.append(biomasses_2)
 
     # Check shapes
@@ -258,26 +263,21 @@ def fixture_biomasses(fixture_biomass_components):
     stem = StemBiomass(cohorts=cohorts, allometry=allometry)
     fruit = FruitBiomass(cohorts=cohorts, allometry=allometry)
     seed = SeedBiomass(cohorts=cohorts, allometry=allometry)
-    return Biomasses(tissues=[foliage, stem, root, fruit, seed])
+    return Biomasses(
+        cohort_id=cohorts["cohort_id"].to_numpy(),
+        tissues=[foliage, stem, root, fruit, seed],
+    )
 
 
 def test_Biomasses_from_cohorts(fixture_biomass_components, fixture_biomasses):
     """Test the biomass from_cohorts class method gives the same result as direct."""
-    from virtual_ecosystem.models.plants.biomasses import (
-        Biomasses,
-        FoliageBiomass,
-        FruitBiomass,
-        RootBiomass,
-        SeedBiomass,
-        StemBiomass,
-    )
+    from virtual_ecosystem.models.plants.biomasses import Biomasses
 
     cohorts, allometry, _, _ = fixture_biomass_components
 
     biomasses = Biomasses.from_cohorts(
         cohorts=cohorts,
         allometry=allometry,
-        tissues=[FoliageBiomass, FruitBiomass, SeedBiomass, StemBiomass, RootBiomass],
     )
 
     for tissue_name in biomasses.tissue_names:
@@ -688,6 +688,7 @@ def test_balance_elements(
 
     cohorts = pd.DataFrame(
         dict(
+            cohort_id=np.arange(len(BALANCE_WOOD_C) * n_cases),
             stem_c_n_ratio=np.tile(BALANCE_WOOD_CN, n_cases),
             stem_c_p_ratio=np.tile(BALANCE_WOOD_CP, n_cases),
             foliage_c_n_ratio=np.tile(BALANCE_FOLIAGE_CN, n_cases),
@@ -725,6 +726,7 @@ def test_balance_elements(
     )
 
     biomasses = Biomasses(
+        cohort_id=cohorts["cohort_id"].to_numpy(),
         tissues=[foliage, wood],
         element_surpluses=np.concatenate(
             [

--- a/tests/models/plants/test_exporter.py
+++ b/tests/models/plants/test_exporter.py
@@ -26,11 +26,6 @@ def fixture_exporter_components(
 
     from virtual_ecosystem.models.plants.biomasses import (
         Biomasses,
-        FoliageBiomass,
-        FruitBiomass,
-        RootBiomass,
-        SeedBiomass,
-        StemBiomass,
     )
     from virtual_ecosystem.models.plants.communities import PlantCommunities
 
@@ -80,13 +75,6 @@ def fixture_exporter_components(
         cell_id: Biomasses.from_cohorts(
             cohorts=cmty.cohorts,
             allometry=cmty.stem_allometry,
-            tissues=[
-                FoliageBiomass,
-                FruitBiomass,
-                SeedBiomass,
-                StemBiomass,
-                RootBiomass,
-            ],
         )
         for cell_id, cmty in communities.items()
     }

--- a/virtual_ecosystem/models/plants/biomasses.py
+++ b/virtual_ecosystem/models/plants/biomasses.py
@@ -24,9 +24,11 @@ representation.
 from __future__ import annotations
 
 from abc import ABC
+from itertools import product
 from typing import ClassVar
 
 import numpy as np
+import pandas as pd
 from numpy.typing import NDArray
 from pyrealm.demography.cohorts import Cohorts
 from pyrealm.demography.tmodel import GrowthIncrements, StemAllocation, StemAllometry
@@ -385,7 +387,7 @@ PLANT_BIOMASS_TISSUES: tuple[type[BiomassTissueABC], ...] = (
 plants model."""
 
 
-class Biomasses:  # TODO - ToDataFrameMixin? Some kind of export method
+class Biomasses:
     """Tissue biomasses for a set of plant cohorts.
 
     A set of plant cohort data and their trait data and stem allometries define the
@@ -410,29 +412,9 @@ class Biomasses:  # TODO - ToDataFrameMixin? Some kind of export method
             across tissues for each cohort.
     """
 
-    # NOTE: these are hard-coded and must be updated if the simulation
-    #       uses different biomass classes.
-    # TODO: Might also be redundant if the ToDataFramMixin approach isn't going to be
-    #       used, which it might well not be - can just concat the tissue arrays into a
-    #       data frame.
-    _array_attrs: ClassVar[tuple[str, ...]] = (
-        "foliage_c_biomass",
-        "foliage_n_biomass",
-        "foliage_p_biomass",
-        "fruit_c_biomass",
-        "fruit_n_biomass",
-        "fruit_p_biomass",
-        "seed_c_biomass",
-        "seed_n_biomass",
-        "seed_p_biomass",
-        "stem_c_biomass",
-        "stem_n_biomass",
-        "stem_p_biomass",
-        "root_c_biomass",
-        "root_n_biomass",
-        "root_p_biomass",
-    )
-    """Array attribute names for all biomass tissue and element data."""
+    # NOTE: the class does not define an _array_attrs class variable, because the actual
+    #       set of exportable attributes depends on the set of tissues (which is
+    #       _usually_ the complete set defined in PLANT_BIOMASS_TISSUES but not always).
 
     def __init__(
         self,
@@ -723,3 +705,36 @@ class Biomasses:  # TODO - ToDataFrameMixin? Some kind of export method
                 other.element_surpluses,
             ]
         )
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Export biomass data to a data frame.
+
+        Returns a dataframe for all cohorts of the elemental biomasses for each tissue
+        and the elemental surplus pool biomasses.
+        """
+
+        # Generate column names
+        columns = [
+            f"{tissue}_{elem}_biomass"
+            for tissue, elem in product(
+                [*[t.tissue_name for t in self.tissues], "surplus"],
+                ["C", *self.elements],
+            )
+        ]
+
+        # Concatenate tissue element masses and surplus by column
+        df = pd.DataFrame(
+            data=np.concat(
+                [
+                    *[t.elemental_masses for t in self.tissues],
+                    self.element_surpluses,
+                ],
+                axis=1,
+            ),
+            columns=columns,
+        )
+
+        # Insert cohort IDs
+        df.insert(loc=0, column="cohort_id", value=self.cohort_id)
+
+        return df

--- a/virtual_ecosystem/models/plants/biomasses.py
+++ b/virtual_ecosystem/models/plants/biomasses.py
@@ -396,10 +396,11 @@ class Biomasses:
     a set of tissues for a particular set of cohorts and provides methods to balance
     tissue stochiometries and add cohorts.
 
-    The :meth:`__init__` constructor takes the arguments show below and provides a
-    simple API that does not require a particular set of tissues. The
-    :meth:`from_config` method generates the complete set of tissues currently required
-    for a simulation, currently with tissues at their ideal stochiometric ratios.
+    The :meth:Biomasses.__init__` constructor takes the arguments show below and
+    provides a simple API that does not require a particular set of tissues. The
+    :meth:`Biomasses.from_cohorts` method generates the complete set of tissues
+    currently required for a simulation, currently with tissues at their ideal
+    stochiometric ratios, for a set of cohorts.
 
     The class is designed to be extendable to new tissues and elements
     by adding them to the tissue type definitions, rather than hard-coding a set of

--- a/virtual_ecosystem/models/plants/biomasses.py
+++ b/virtual_ecosystem/models/plants/biomasses.py
@@ -374,15 +374,40 @@ class RootBiomass(BiomassTissueABC):
     turnover_ratio_attrs = "root_c_ELEM_ratio"
 
 
+PLANT_BIOMASS_TISSUES: tuple[type[BiomassTissueABC], ...] = (
+    FoliageBiomass,  # foliage mass
+    StemBiomass,  # stem mass
+    RootBiomass,  # fine root mass
+    FruitBiomass,  # fruit tissue mass
+    SeedBiomass,  # seed tissue mass
+)
+"""A tuple of the complete set of tissue biomass classes currently required in the
+plants model."""
+
+
 class Biomasses:  # TODO - ToDataFrameMixin? Some kind of export method
-    """A class holding biomasses for a set of plant cohorts and tissues.
+    """Tissue biomasses for a set of plant cohorts.
 
-    This class holds the current ratios across tissue type for a community object, which
-    in essence is a series of cohorts. It acts in parallel with StemAllometry, a class
-    attribute of Community.
+    A set of plant cohort data and their trait data and stem allometries define the
+    theoretical expectations carbon masses and stoichiometry under the T
+    Model :cite:p:`li_simulation_2014` for a set of plant tissues. This class manages
+    a set of tissues for a particular set of cohorts and provides methods to balance
+    tissue stochiometries and add cohorts.
 
-    The class is designed to be element-agnostic, so it can be used for any element as
-    required.
+    The :meth:`__init__` constructor takes the arguments show below and provides a
+    simple API that does not require a particular set of tissues. The
+    :meth:`from_config` method generates the complete set of tissues currently required
+    for a simulation, currently with tissues at their ideal stochiometric ratios.
+
+    The class is designed to be extendable to new tissues and elements
+    by adding them to the tissue type definitions, rather than hard-coding a set of
+    elements.
+
+    Args:
+        cohort_ids: A numpy array of cohort id values
+        tissues: A list of biomass tissue instances.
+        element_surpluses: An optional array providing initial elemental surpluses
+            across tissues for each cohort.
     """
 
     # NOTE: these are hard-coded and must be updated if the simulation
@@ -411,13 +436,20 @@ class Biomasses:  # TODO - ToDataFrameMixin? Some kind of export method
 
     def __init__(
         self,
+        cohort_id: NDArray,
         tissues: list[BiomassTissueABC],
         element_surpluses: NDArray[np.floating] | None = None,
     ) -> None:
+        """Simple Biomasses instance constructor.
 
-        # TODO - do we actually need this constructor as opposed to just using the
-        #        from_cohorts method as __init__?
+        This constructor function provides a simple API to generate Biomasses()
+        instances with an arbitrary set of tissues, which is useful for testing. In
+        actual use in the model, the ``from_cohorts()`` method is used to generate an
+        instance with the complete set of simulated tissues.
+        """
 
+        self.cohort_id: NDArray = cohort_id
+        """Cohort IDs for the cohorts."""
         self.tissues: list[BiomassTissueABC] = tissues
         """Tissues for the associated cohorts."""
         self.element_surpluses: NDArray[np.floating]
@@ -465,14 +497,15 @@ class Biomasses:  # TODO - ToDataFrameMixin? Some kind of export method
         cls,
         cohorts: Cohorts,
         allometry: StemAllometry,
-        tissues: list[type[BiomassTissueABC]],
     ):
         """Create a Biomasses instance from cohort data using the ideal element ratios.
+
+        This generates a Biomasses instance containing all of the currently required
+        tissue types, defined in the :data:`PLANT_BIOMASS_TISSUES` global variable.
 
         Args:
             cohorts: A data frame of cohorts providing trait data.
             allometry: The allometry of the cohorts.
-            tissues: A list of tissue models to be used.
 
         Returns:
             An instance of Biomasses with default element ratios for the cohorts.
@@ -484,10 +517,10 @@ class Biomasses:  # TODO - ToDataFrameMixin? Some kind of export method
                 cohorts=cohorts,
                 allometry=allometry,
             )
-            for tissue in tissues
+            for tissue in PLANT_BIOMASS_TISSUES
         ]
 
-        return cls(tissues=default_tissues)
+        return cls(cohort_id=cohorts["cohort_id"].to_numpy(), tissues=default_tissues)
 
     @property
     def total_element_masses(self) -> NDArray[np.floating]:
@@ -676,7 +709,10 @@ class Biomasses:  # TODO - ToDataFrameMixin? Some kind of export method
     def append(self, other: Biomasses):
         """Append data from another Biomasses instance representing new cohorts."""
 
-        # TODO check tissues and elements?
+        # TODO check tissues and elements align?
+
+        # Concatenate cohort IDs and surpluses and apply append method for tissues.
+        self.cohort_id = np.concat([self.cohort_id, other.cohort_id])
 
         for tissue_name in self.tissue_names:
             self.get_tissue(tissue_name).append(other.get_tissue(tissue_name))

--- a/virtual_ecosystem/models/plants/exporter.py
+++ b/virtual_ecosystem/models/plants/exporter.py
@@ -90,7 +90,7 @@ class CommunityDataExporter:
                 #    and that does not have columns. Need to work out how to repopulate
                 #    this list
                 *StemAllocation._array_attrs,
-                *Biomasses._array_attrs,
+                # *Biomasses._array_attrs,
             ]
         ),
         "community_canopy_attributes": set(

--- a/virtual_ecosystem/models/plants/plants_model.py
+++ b/virtual_ecosystem/models/plants/plants_model.py
@@ -33,12 +33,6 @@ from virtual_ecosystem.models.hydrology.model_config import (
 )
 from virtual_ecosystem.models.plants.biomasses import (
     Biomasses,
-    BiomassTissueABC,
-    FoliageBiomass,
-    FruitBiomass,
-    RootBiomass,
-    SeedBiomass,
-    StemBiomass,
     partition_reproductive_tissue_mass,
 )
 from virtual_ecosystem.models.plants.canopy import (
@@ -255,9 +249,6 @@ class PlantsModel(
         self.biomasses: dict[int, Biomasses]
         """A dictionary keyed by cell id of the carbon and nutrient biomass of each
         community."""
-        self.biomass_tissues: list[type[BiomassTissueABC]]
-        """A list of types of biomass subclasses that sets the tissues to be
-        modelled within the simulation."""
         self.allocations: dict[int, StemAllocation]
         """A dictionary keyed by cell id giving the allocation of each community."""
         self._canopy_layer_indices: NDArray[np.bool_]
@@ -396,15 +387,6 @@ class PlantsModel(
                 )
             )
 
-        # Define the set of tissues to be tracked for each stem.
-        self.biomass_tissues = [
-            FoliageBiomass,  # foliage mass
-            StemBiomass,  # stem mass
-            RootBiomass,  # fine root mass
-            FruitBiomass,  # fruit tissue mass
-            SeedBiomass,  # seed tissue mass
-        ]
-
         # Record the per stem biomasses of stochiometric tissues for each cohort.
         # The initial values for N and P are based on the ideal stoichiometric ratios
         # defined in the plant traits.
@@ -412,7 +394,6 @@ class PlantsModel(
             cell_id: Biomasses.from_cohorts(
                 cohorts=community.cohorts,
                 allometry=community.stem_allometry,
-                tissues=self.biomass_tissues,
             )
             for cell_id, community in self.communities.items()
         }
@@ -1663,7 +1644,6 @@ class PlantsModel(
                 new_biomasses = Biomasses.from_cohorts(
                     cohorts=new_community.cohorts,
                     allometry=new_community.stem_allometry,
-                    tissues=self.biomass_tissues,
                 )
 
                 self.biomasses[cell_id].append(new_biomasses)


### PR DESCRIPTION
# Description

This PR makes usability changes to the Biomasses API:

* Defines the simulation complete set of tissues as a global variable in Biomasses rather than nesting it within PlantsModel. This is partly to expose that list within the model objects, but mostly it is just a more logical place to define the set.
* The class now includes `cohort_id` to allow consistent mapping of rows to cohorts.
* Adds a `to_dataframe` method that exports the elemental mass pools for all tissues _and_ surpluses.
* Removes `Biomasses._array_attrs` - unless we pin `Biomasses` to always use the complete set of tissues [^1], then the actual set tissues in an instance is variable and so class _does not really have_ a constant set of array fields. We'll have to fix the only use of that attribute (in the exporter) some other way - upcoming in #1820.
* Updates tests and docstrings. 

Fixes #1826

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Relevant documentation reviewed and updated

[^1]: We do in `from_config` which makes sense but we don't through `__init__` at present and this is really handy for testing element balancing on a more manage set of 2 tissues, not all 5.