### PR TITLE
Litter environmental factors documentation update

### DIFF
--- a/docs/source/virtual_ecosystem/theory/soil/environmental_links.md
+++ b/docs/source/virtual_ecosystem/theory/soil/environmental_links.md
@@ -98,8 +98,10 @@ $$f_t(T) = \exp{\left(\gamma \frac{T - T_{\mathrm{ref}}}{T + T_{\mathrm{off}}}\r
 
 where $T$ is the litter temperature, $T_\mathrm{ref}$ is reference temperature used to
 establish "intrinsic" litter decay rates, $T_\mathrm{off}$ is an offset temperature, and
-$\gamma$ is a parameter capturing how responsive litter decay rates are to temperature
-changes.
+$\gamma$ is a parameter that sets response strength by setting the high and low
+temperature limits of the response, e.g.
+$\lim\limits_{T\to \infty}f_t(T) = \exp{(\gamma)}$
+and $\lim\limits_{T\to -\infty}f_t(T) = \exp{(-\gamma)}$.
 
 ### Litter decay moisture response
 

--- a/docs/source/virtual_ecosystem/theory/soil/environmental_links.md
+++ b/docs/source/virtual_ecosystem/theory/soil/environmental_links.md
@@ -113,10 +113,15 @@ becomes limiting. The "intrinsic" process rates are altered to capture the effec
 soil moisture by multiplying them with a factor that takes the following form
 
 $$
-A(\psi) = 1 - \left(
+A(\psi) =
+\begin{cases}
+1, \quad \psi \geq \psi_{o} \\
+1 - \left(
 \frac{\log_{10}|\psi| - \log_{10}|\psi_{o}|}
 {\log_{10}|\psi_{h}| - \log_{10}|\psi_{o}|}
-\right)^\alpha,
+\right)^\alpha, \quad \psi_{h} < \psi < \psi_{o} \\
+0, \quad \psi \leq \psi_{h}
+\end{cases}
 $$
 
 where $\psi$ is the soil water potential, $\psi_{o}$ is the "optimal" water potential at
@@ -160,7 +165,7 @@ that temperature has on denitrification rate to be calculated as
 $$
 f_{T,d}(T) =
 \begin{cases}
-0, \quad T <= T_h \\
+0, \quad T \leq T_h \\
 f_\infty * \exp{\left(-\frac{s_d}{T - T_h}\right)}, \quad T > T_h \\
 \end{cases}
 $$
@@ -210,10 +215,10 @@ f_p =
 \begin{cases}
 0, \quad pH < pH_\mathrm{min} \\
 \frac{pH - pH_\mathrm{min}}{pH_l - pH_\mathrm{min}}, \quad
-pH_\mathrm{min} < pH < pH_l \\
-1, \quad pH_l < pH < pH_u \\
+pH_\mathrm{min} \leq pH < pH_l \\
+1, \quad pH_l \leq pH \leq pH_u \\
 \frac{pH_\mathrm{max} - pH}{pH_\mathrm{max} - pH_u}, \quad
-pH_u < pH < pH_\mathrm{max} \\
+pH_u < pH \leq pH_\mathrm{max} \\
 0, \quad pH > pH_\mathrm{max}
 \end{cases}
 $$

--- a/docs/source/virtual_ecosystem/theory/soil/litter_theory.md
+++ b/docs/source/virtual_ecosystem/theory/soil/litter_theory.md
@@ -171,15 +171,14 @@ rates.
 The decay of all litter pools are assumed to follow linear kinetics, with the rate of
 change in the carbon mass, $P$, of litter pool $j$ being given by
 
-$$\frac{dP_j}{dt} = I_j - K_j(T,\psi,L)P_j,$$
+$$\frac{dP_j}{dt} = I_{C,j} - K_j(T,\psi,L)P_j,$$
 
-where $I_j$ is the rate of input to pool $j$ (in carbon terms), $T$ is the temperature,
-$\psi$ is the soil water potential and $K_j(T,\psi,L)$ is the decay rate of the pool.
-The decay rate of the pool will always depend on temperature, but only for the
-below-ground pools will it be affected by soil water potential. Further, lignin content
-only affects the decay rates of pools which contain lignin (i.e. structural and woody
-pools). As an example, the decay rate of the below-ground structural litter pool is
-calculated as
+where $I_{C,j}$ is the rate of carbon input to pool $j$, $T$ is the temperature, $\psi$
+is the soil water potential and $K_j(T,\psi,L)$ is the decay rate of the pool. The decay
+rate of the pool will always depend on temperature, but only for the below-ground pools
+will it be affected by soil water potential. Further, lignin content only affects the
+decay rates of pools which contain lignin (i.e. structural and woody pools). As an
+example, the decay rate of the below-ground structural litter pool is calculated as
 
 $$K_{bs}(T,\psi,L) = k_{bs} * f_t(T) * A(\psi) * f_l(L),$$
 
@@ -197,19 +196,108 @@ litter pool size at the end of the model update interval ($\tau$). This solution
 expressed as
 
 $$
-P_j(\tau) = \frac{I_j}{K_j(T,\psi,L)} - \left(\frac{I_j}{K_j(T,\psi,L)} -
+P_j(\tau) = \frac{I_{C,j}}{K_j(T,\psi,L)} - \left(\frac{I_{C,j}}{K_j(T,\psi,L)} -
     P_{j,0}\right) e^{-K_j(T,\psi,L)\tau},
 $$
 
-where $P_{j,0}$ is the size of litter pool $j$ at the start of the update interval. We
-don't use comparable exact solutions for the nitrogen, phosphorus and lignin dynamics.
-Instead, we estimate the loss of each chemical based on the loss of carbon. This
-estimation assumes that old litter (i.e. litter that is there at the start of the time
-step) decays first and that litter added during the update only decays if the total
-decay of litter exceeds the initial litter pool size. Total loss of the chemicals is
-then found either using the initial pool chemistry (if total decay is less than the
-initial pool size), or a weighted average of the initial pool chemistry and the
-chemistry of the input biomass.
+where $P_{j,0}$ is the size of litter pool $j$ at the start of the update interval.
+
+## Litter mineralisation
+
+We now want to find the amount of carbon that is mineralised into the soil, the amount
+of carbon respired from the litter, the amount of nitrogen and phosphorus mineralised
+into the soil, and the amount of lignin lost by the litter pools. To calculate all these
+things we first have to find the total carbon loss from each litter pool, which is given
+by
+
+$$
+L_j(\tau) = P_{j,0} + \Theta_j(\tau) - P_j(\tau).
+$$
+
+where $\Theta_j(\tau)$ is the total input to litter pool $j$ over the time step $\tau$,
+which is calculated as
+
+$$
+\Theta_j(\tau) = \tau * I_{C,j}.
+$$
+
+### Carbon mineralisation
+
+With the carbon loss from each pool found, it is trivial to calculate the mass of carbon
+mineralised over the simulation time step, which is given by.
+
+$$
+M_C(\tau) = \sum^5_{j=1} \epsilon_j * L_j(\tau),
+$$
+
+where $\epsilon_j$ is the carbon use efficiency of litter breakdown for litter pool $j$.
+
+### Respiration
+
+Any carbon that is not mineralised by definition has to be respired, so total
+respiration is calculated as
+
+$$
+R(\tau) = \sum^5_{j=1} (1 - \epsilon_j) * L_j(\tau).
+$$
+
+As a simplifying assumption we assume that these carbon use efficiencies ($\epsilon_j$)
+**do not** vary with temperature. However, litter respiration will still vary with
+temperature as the [rate of litter decay varies with
+temperature](./environmental_links.md#litter-decay-temperature-response).
+
+### Macronutrient mineralisation
+
+By definition all macronutrient loss (nitrogen and phosphorus) from the litter is
+mineralised to the soil. Unfortunately, there is no exact solution for the macronutrient
+losses. Instead, the loss of each macronutrient has to be estimated based on the loss of
+carbon. The estimate is based on the assumption that old litter (i.e. litter that is
+there at the start of the time step) decays first and that litter added during the
+update only decays if the total decay of litter exceeds the initial litter pool size.
+Using this assumption the total mineralisation of macronutrient $k$ over the time step
+length ($\tau$) can be estimated as
+
+$$
+M_k(\tau) = \sum^5_{j=1} (\theta_{0,j} * N_{k,j,0} + \theta_{n,j} * I_{k,j} * \tau),
+$$
+
+where $\theta_{0,j}$ is the fraction of the initial mass of litter pool $j$ that is
+assumed to have decayed, $\theta_{n,j}$ is the fraction of the new input to litter pool
+$j$ that is assumed to have decayed, $N_{k,j,0}$ is the initial mass of macronutrient
+$k$ in litter pool $j$ and $I_{k,j}$ is the input rate of macronutrient $k$ into litter
+pool $j$.
+
+The decay fractions are calculated as
+
+$$
+\theta_{0,j} = \begin{cases}
+L_j(\tau) / P_{j,0}, \quad L_j(\tau) \leq P_{j,0} \\
+1, \quad L_j(\tau) > P_{j,0}
+\end{cases}
+$$
+
+and
+
+$$
+\theta_{n,j} = \begin{cases}
+0, \quad L_j(\tau) \leq P_{j,0} \\
+\frac{L_j(\tau) - P_{j,0}}{\Theta_j(\tau)}, \quad L_j(\tau) \leq P_{j,0}.
+\end{cases}
+$$
+
+### Lignin loss
+
+Lignin is only currently tracked by the litter model, so mineralisation of lignin into
+the soil does not need to be tracked. However, the loss of lignin from the relevant
+litter pools does need to be estimated. This is done following the same procedure used
+for macronutrients, with lignin loss from litter pool $j$ estimated using
+
+$$
+d_{l,j}(\tau) = \theta_{0,j} * N_{L,j,0} + \theta_{n,j} * I_{L,j} * \tau,
+$$
+
+where $N_{L,j,0}$ is the initial mass of lignin in litter pool $j$ and $I_{L,j}$ is the
+input rate of lignin into litter pool $j$.
 
 :::{admonition} Future directions 🔭
 


### PR DESCRIPTION
# Description

Two of the changes I have made a pretty minor. They are:

1. Giving a proper explanation of what a "response" parameter means in terms of the shape of the function
2. Correcting the limits given for various environmental functions

The substantive change I've made is adding the equations for the calculation of litter mineralisation (of carbon, nitrogen and phosphorus), litter respiration and lignin loss from litter. This entails adding a fair amount of documentation, so if you can see anyway that it could be made clearer let me know!

This is [relevant branch of the docs to look at](https://virtual-ecosystem.readthedocs.io/en/1801-litter-environmental-factors-documentation/virtual_ecosystem/theory/soil/summary.html).

Fixes #1801 
